### PR TITLE
Switch back to net-dns

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@
 source "http://rubygems.org"
 
 gem "rspec"
+gem "rspec-mocks"
 gem "flexmock"
-gem "net-dns2"
+gem "net-dns"
 gem "test-unit"
 gem "rack-test"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,8 @@ GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.2.5)
-    flexmock (0.8.11)
-    net-dns2 (0.8.7)
-      packetfu
-    network_interface (0.0.1)
-    packetfu (1.1.11)
-      network_interface (~> 0.0)
-      pcaprub (~> 0.12)
-    pcaprub (0.12.0)
+    flexmock (2.0.3)
+    net-dns (0.8.0)
     power_assert (0.2.6)
     rack (1.6.4)
     rack-test (0.6.3)
@@ -35,9 +29,10 @@ PLATFORMS
 
 DEPENDENCIES
   flexmock
-  net-dns2
+  net-dns
   rack-test
   rspec
+  rspec-mocks
   test-unit
 
 BUNDLED WITH

--- a/project-honeypot.gemspec
+++ b/project-honeypot.gemspec
@@ -1,13 +1,13 @@
 Gem::Specification.new do |s|
   s.name = %q{project-honeypot}
-  s.version = "0.1.4"
+  s.version = "0.1.5"
   s.date = %q{2015-07-02}
   s.authors = ["Charles Max Wood"]
   s.email = %q{chuck@teachmetocode.com}
   s.summary = %q{Project-Honeypot provides a programatic interface to the Project Honeypot services.}
   s.homepage = %q{http://teachmetocode.com/}
   s.description = %q{Project-Honeypot provides a programatic interface to the Project Honeypot services. It can be used to identify spammers, bogus commenters, and harvesters. You will need a FREE api key from http://projecthoneypot.org}
-  s.add_dependency('net-dns2')
+  s.add_dependency('net-dns')
   s.add_dependency('test-unit')
 
   s.files         = `git ls-files`.split("\n")

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -3,11 +3,12 @@ require "spec_helper"
 describe ProjectHoneypot::Base do
   describe "with honeypot response" do
     before(:each) do
-      flexmock(Net::DNS::Resolver, :start => flexmock("answer", :answer => ["somedomain.httpbl.org A Name 127.1.63.5"]))
+      allow(Net::DNS::Resolver).to receive_message_chain(:start, :answer).and_return(["somedomain.httpbl.org A Name 127.1.63.5"])
       @base = ProjectHoneypot::Base.new("abcdefghijklmnop")
     end
 
     it "returns a Url object" do
+      expect(Net::DNS::Resolver).to receive(:start).once
       url = @base.lookup("127.10.10.5")
       expect(url).to be_a ProjectHoneypot::Url
       expect(url.last_activity).to eq(1)
@@ -15,8 +16,8 @@ describe ProjectHoneypot::Base do
     end
 
     it "looks up non-ip addresses" do
+      expect(Net::DNS::Resolver).to receive(:start).twice
       url = @base.lookup("iamspam.com")
-      Net::DNS::Resolver.should_receive(:start).with("iamspam.com")
     end
   end
 end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -23,10 +23,11 @@ describe ProjectHoneypot::Middleware do
 
   describe "good request" do
     before(:each){
-      flexmock(Net::DNS::Resolver, :start => flexmock("answer", :answer => [nil]))
+      allow(Net::DNS::Resolver).to receive_message_chain(:start, :answer).and_return([nil])
     }
     
     it 'says Hello World' do
+      allow(ProjectHoneypot::Base).to receive(:lookup).and_return([nil])
       post '/', {}, 'REMOTE_ADDR' => @ip
       expect(last_response).to be_ok
       expect(last_response.body).to eq('Hello World')
@@ -35,7 +36,7 @@ describe ProjectHoneypot::Middleware do
   
   describe "bad request" do
     before(:each){
-      flexmock(Net::DNS::Resolver, :start => flexmock("answer", :answer => ["somedomain.httpbl.org A Name 127.82.64.5"]))
+      allow(Net::DNS::Resolver).to receive_message_chain(:start, :answer).and_return(["somedomain.httpbl.org A Name 127.82.64.5"])
     }
     
     it 'says WARNING' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,10 @@
 require "rubygems"
 require "bundler/setup"
 require "rspec"
+require "rspec/mocks"
 require 'rack/test'
 require "flexmock"
 require "project-honeypot"
 
 RSpec.configure do |config|
-  config.mock_with :flexmock
 end


### PR DESCRIPTION
net-dns2 includes a couple extra libraries that are unnecessary, and one of which (pcaprub) fails to compile on Heroku (see below).  This fix switches back to net-dns and also switches from flexmock to spec-mocks, because flexmock had issues with net-dns.
